### PR TITLE
自動画面更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,9 @@
 $(function(){
   $(document).on('turbolinks:load', function() { 
     function buildMessage(message){
-      var image = message.image ? `<img src="${message.image}">`: " ";
-      var html = `<div class="message_box">
+      var text = message.text ? `${message.text}` : " ";
+      var image = message.image ? `<img class="lower-info__image" src="${message.image}">`: " ";
+      var html = `<div class="message_box" data-message-id="${message.id}">
                     <div class="right-contents__maine--info">
                       <div class="right-contents__maine--info--user">
                         ${message.name}
@@ -13,7 +14,7 @@ $(function(){
                     </div>
                     <div class="right-contents__maine--text">
                       <p class="lower-message__text">
-                        ${message.text}
+                        ${text}
                       </p>
                       ${image}
                     </div>
@@ -45,5 +46,30 @@ $(function(){
         $('.send').removeAttr("disabled");
       })
     });
+    
+    var reloadMessages = function() {
+      if (window.location.href.match(/\/groups\/\d+\/messages/)){
+        var url = 'api/messages#index {:format=>"json"}'
+        var message_id = $('.message_box:last').data('message-id');
+        $.ajax({
+          url: url,
+          type: "GET",
+          data: {id: message_id},
+          dataType: "json"
+        })
+        .done(function(messages) {
+          var html = '';
+          messages.forEach(function(message) {
+            html = buildMessage(message);
+            $('.right-contents__maine').append(html);
+            $('.right-contents__maine').animate({scrollTop: $('.right-contents__maine')[0].scrollHeight}, 'fast'); 
+          });
+        })
+        .fail(function() {
+          alert('自動更新に失敗しました');
+        });
+      }
+    }
+    setInterval(reloadMessages, 3000);
   });
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,9 @@
+class Api::MessagesController < ApplicationController
+  
+  def index
+    @group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = @group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.text message.text
+  json.image message.image.url
+  json.date message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message_box
+.message_box{data:{message:{id: "#{message.id}"}}}
   .right-contents__maine--info
     .right-contents__maine--info--user
       =message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.name @message.user.name
 json.date @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.text @message.text
 json.image @message.image.url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only:[:index, :edit, :update]
   resources :groups, only:[:new, :create, :edit, :update] do
     resources :messages, only:[:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#What
ajax, apiを使用し、自動的にチャット画面を更新するような機能を実装した。

#Why
従来ではメッセージ受信者は、チャット画面をリロードしないと新規メッセージが読み込めない使用であったため、自動更新をかけることによってリアルタイムでチャットすることが可能になる。